### PR TITLE
Fix SCT Shutdown_Func test failure

### DIFF
--- a/Silicon/Marvell/Drivers/Net/Pp2Dxe/Pp2Dxe.c
+++ b/Silicon/Marvell/Drivers/Net/Pp2Dxe/Pp2Dxe.c
@@ -685,6 +685,7 @@ Pp2SnpShutdown (
     }
   }
 
+  This->Mode->State = EfiSimpleNetworkStarted;
   ReturnUnlock (SavedTpl, EFI_SUCCESS);
 }
 


### PR DESCRIPTION
Error message 

```
EFI_SIMPLE_NETWORK_PROTOCOL.Shutdown - Invoke Shutdown() and verify interface co
rrectness within test case -- FAILURE
49365EEB-D66C-4109-B0CF-36C896C007EC
/home/jisjos01/EAC_1.0/final/arm-systemready/ES/scripts/edk2-test/uefi-sct/SctPk
g/TestCase/UEFI/EFI/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTestFunct
ion.c:656:Status - Success
```
